### PR TITLE
Update the REST server and connection profile steps

### DIFF
--- a/_pages/03_Interacting with your blockchain.md
+++ b/_pages/03_Interacting with your blockchain.md
@@ -38,7 +38,7 @@ Using your cluster's `Public IP` you can now access the Hyperledger Composer Pla
 http://YOUR_PUBLIC_IP_HERE:31080
 ```
 
-### 3. Develop Your Business Network
+### 3. Develop And Deploy Your Business Network
 
 Hyperledger Composer provides a tutorial for using Playground to create a basic Business Network.  We recommend you follow this to get to grips with the programming model:
 
@@ -48,157 +48,81 @@ Hyperledger Composer provides a tutorial for using Playground to create a basic 
 
 Once you've deployed a Business Network Definition that you're happy to start writing some applications against, you can expose it as a REST API...
 
-### 4. Start and Access the Composer REST Server
+### 4. Expose Your Business Network As A REST API
 
-You can deploy a Hyperledger Composer REST Server after you have deployed a Business Network Definition.  Whilst you _could_ do this as soon as you've accessed Playground (as the Basic Sample Network will be deployed by default), we recommend you start by developing your Business Network Definition and only stand up the REST Server when you've got something you want to develop applications against.
+Before performing this step, you must first have deployed a Business Network. You can use the Hyperledger Composer Playground, command line (CLI), or Node.js APIs to deploy a Business Network. For more information on deploying Business Networks, see the Hyperledger Composer documentation.
 
-For more getting started information on this see the [Composer REST server documentation](https://hyperledger.github.io/composer/integrating/integrating-index.html)
+The Hyperledger Composer REST server allows you to expose your deployed Business Network via a REST API. Client applications, such as web or mobile applications, can interact with your deployed Business Network by using a REST or HTTP client. For more information on the Hyperledger Composer REST server and integrating existing systems with your deployed Business Network, see the [Integrating existing systems documentation](https://hyperledger.github.io/composer/integrating/integrating-index.html).
 
-Unless you've done something outside the scope of these instructions, the file `kube-configs/composer-rest-server.yaml` is already set up to work with the Business Network that you have deployed.
+1. Start the Hyperledger Composer REST server for a deployed Business Network by running the following commands. Replace `INSERT_BIZNET_NAME` with the name of the Business Network.
 
-Deploy the composer rest server:
-```
-cd cs-offerings/free/scripts/
-./create/create_composer-rest-server.sh
-```
+		cd cs-offerings/free/scripts/
+		./create/create_composer-rest-server.sh INSERT_BIZNET_NAME
 
-Determine the public IP address of the cluster as in Step 1.
+2. Determine the public IP address of the cluster as in Step 1.
 
-Using the value of the `Public IP` (in this example 169.48.140.99) you can now access the Hyperledger Composer REST server at:
-```
-http://YOUR_PUBLIC_IP_HERE:31090/explorer/
-```
+3. Using the value of the `Public IP` (in this example 169.48.140.99) you can now access the Hyperledger Composer REST server at:
 
-### Connections Profile for external apps to talk to your blockchain network
+		http://YOUR_PUBLIC_IP_HERE:31090/explorer/
 
-For the external apps to connect to your blockchain network, just replace `INSERT_PUBLIC_IP` with your public IP from the previous step.  
-```
-{
-	"name": "ibm-cs",
-	"x-networkId": "not-important",
-	"x-type": "hlfv1",
-	"description": "Connection Profile for an IBM Blockchain Network on IBM CS",
-	"version": "1.0.1",
-	"client": {
-		"organization": "PeerOrg1"
-	},
-	"channels": {
-		"mychannel": {
+### 5. Build A Connection Profile For Your Deployed Business Network
+
+In order to interact with your deployed Business Network using the Hyperledger Composer command line (CLI) or Node.js APIs, you must create a Hyperledger Composer connection profile. A Hyperledger Composer connection profile defines all of the information required to access the Hyperledger Fabric network, for example the URLs of the peers.
+
+For more information on Hyperledger Composer connection profiles, see the [Connection Profiles documentation](https://hyperledger.github.io/composer/reference/connectionprofile.html)
+
+The Hyperledger Fabric network created by these scripts defines two organisations called `org1` and `org2`. In order to create a Hyperledger Composer connection profile for use by `org1`, perform the following steps:
+
+1. Determine the public IP address of the cluster as in Step 1. The public IP address will be used later in the contents of the connection profile file.
+
+2. Connection profiles are stored in a connection profile folder. The name of the connection profile folder is also the name of the connection profile. Create a connection profile folder named `ibm-bc-org1`:
+
+		mkdir -p $HOME/.composer-connection-profiles/ibm-bc-org1
+		cd $HOME/.composer-connection-profiles/ibm-bc-org1
+		pwd
+
+	The full path to the connection profile folder will be printed by the `pwd` command. It will contain the path to your home directory, for example `/home/testuser/.composer-connection-profiles/ibm-bc-org1`. You will need to remember this path in order to create the connection profile.
+
+3. Blockchain identities, or digital certificates, are stored in a credentials folder. Create a credentials folder that will be used to store Blockchain identities which are used for the `ibm-bc-org1` connection profile:
+
+		mkdir -p $HOME/.composer-credentials/ibm-bc-org1
+		cd $HOME/.composer-credentials/ibm-bc-org1
+		pwd
+
+	The full path to the credentials folder will be printed by the `pwd` command. It will contain the path to your home directory, for example `/home/testuser/.composer-credentials/ibm-bc-org1`. You will need to remember this path in order to create the connection profile.
+
+4. Finally, using your favourite editor, create a connection profile file named `connection.json` in the connection profile folder. This is the path that you determined in step 2.
+
+	The contents of the connection profile file should be as follows. Replace all instances of `INSERT_PUBLIC_IP` with the IP address that you determined in step 1. Replace all instances of `INSERT_CREDENTIALS_PATH` with the path to the credentials folder that you determined in step 3.
+
+		{
+			"name": "ibm-bc-org1",
+			"description": "Connection profile for IBM Blockchain Platform",
+			"type": "hlfv1",
 			"orderers": [
-				"blockchain-orderer"
-			],
-			"peers": {
-				"org1peer1": {
-					"endorsingPeer": true,
-					"chaincodeQuery": true,
-					"ledgerQuery": true,
-					"eventSource": true
-				},
-				"org2peer1": {
-					"endorsingPeer": true,
-					"chaincodeQuery": true,
-					"ledgerQuery": true,
-					"eventSource": true
-				}
-			},
-			"chaincodes": {
-			},
-			"x-blockDelay": 1000
-		}
-	},
-	"organizations": {
-		"PeerOrg1": {
-			"mspid": "Org1MSP",
-			"peers": [
-				"org1peer1"
-			],
-			"certificateAuthorities": [
-				"blockchain-ca-org1"
-			]
-		},
-		"PeerOrg2": {
-			"mspid": "Org2MSP",
-			"peers": [
-				"org2peer1"
-			],
-			"certificateAuthorities": [
-				"blockchain-ca-org2"
-			]
-		}
-	},
-	"orderers": {
-		"blockchain-orderer": {
-			"url": "grpc://INSERT_PUBLIC_IP:31010",
-			"grpcOptions": {
-				"ssl-target-name-override": null,
-				"grpc.http2.keepalive_time": 15
-			},
-			"tlsCACerts": {
-				"pem": null
-			}
-		},
-	},
-	"peers": {
-		"org1peer1": {
-			"url": "grpc://INSERT_PUBLIC_IP:30110",
-			"eventUrl": "grpc://INSERT_PUBLIC_IP:30111",
-			"grpcOptions": {
-				"ssl-target-name-override": null,
-				"grpc.http2.keepalive_time": 15
-			},
-			"tlsCACerts": {
-				"pem": null
-			}
-		},
-		"org2peer1": {
-			"url": "grpc://INSERT_PUBLIC_IP:30210",
-			"eventUrl": "grpc://INSERT_PUBLIC_IP:30211",
-			"grpcOptions": {
-				"ssl-target-name-override": null,
-				"grpc.http2.keepalive_time": 15
-			},
-			"tlsCACerts": {
-				"pem": null
-			}
-		}
-	},
-	"certificateAuthorities": {
-		"blockchain-ca-org1": {
-			"url": "http://INSERT_PUBLIC_IP:30000",
-			"httpOptions": {
-				"verify": true
-			},
-			"tlsCACerts": {
-				"pem": null
-			},
-			"registrar": [
 				{
-					"affiliation": ""
-					"enrollId": "admin",
-					"enrollSecret": "adminpw"
+					"url": "grpc://INSERT_PUBLIC_IP:31010"
 				}
 			],
-			"caName": "CA1"
-		},
-		"blockchain-ca-org2": {
-			"url": "http://INSERT_PUBLIC_IP:30000",
-			"httpOptions": {
-				"verify": true
+			"ca": {
+				"url": "http://INSERT_PUBLIC_IP:30000",
+				"name": "CA1"
 			},
-			"tlsCACerts": {
-				"pem": null
-			},
-			"registrar": [
+			"peers": [
 				{
-					"affiliation": "",
-					"enrollId": "admin",
-					"enrollSecret": "adminpw"
+					"requestURL": "grpc://INSERT_PUBLIC_IP:30110",
+					"eventURL": "grpc://INSERT_PUBLIC_IP:30111"
 				}
 			],
-			"caName": "CA2"
+			"keyValStore": "INSERT_CREDENTIALS_PATH",
+			"channel": "channel1",
+			"mspID": "Org1MSP",
+			"timeout": 300
 		}
-	}
-}
-```
+
+5. You can now use the Hyperledger Composer connection profile `ibm-bc-org1` with the Hyperledger Composer CLI application `composer`, or the Hyperledger Composer Node.js APIs. You can test this by using the `composer network ping` command to ping a deployed Business Network. Replace `INSERT_BIZNET_NAME` with the name of the Business Network.
+
+		composer network ping -p ibm-bc-org1 -n INSERT_BIZNET_NAME -i admin -s adminpw
+
 ## Congratulations!
 You've got a full development environment up and running!  Go create something exciting with IBM Blockchain!


### PR DESCRIPTION
The REST server step is out of date, as the script now requires the name of the business network as the first argument. The connection profile step is useless, as it shows you how to create a connection profile in a format nothing understands _yet_.