### PR TITLE
Update IBM Container Service scripts to use latest Hyperledger Composer

### DIFF
--- a/_pages/03_Interacting with your blockchain.md
+++ b/_pages/03_Interacting with your blockchain.md
@@ -107,7 +107,7 @@ The Hyperledger Fabric network created by these scripts defines two organisation
 				}
 			],
 			"ca": {
-				"url": "http://INSERT_PUBLIC_IP:30000",
+				"url": "http://INSERT_PUBLIC_IP:30054",
 				"name": "CA1"
 			},
 			"peers": [

--- a/_pages/13_Interacting with your blockchain Paid.md
+++ b/_pages/13_Interacting with your blockchain Paid.md
@@ -19,7 +19,7 @@ Determine the public IP address of each service by running the following command
 ```bash
 $ kubectl get svc
 NAME                   CLUSTER-IP       EXTERNAL-IP     PORT(S)                           AGE
-blockchain-ca          172.21.19.128    169.48.207.86   30000:30000/TCP                   4m
+blockchain-ca          172.21.19.128    169.48.207.86   30054:30054/TCP                   4m
 blockchain-orderer     172.21.194.183   169.47.102.85   31010:31010/TCP                   4m
 blockchain-org1peer1   172.21.165.205   169.48.207.83   30110:30110/TCP,30111:30111/TCP   4m
 blockchain-org2peer1   172.21.174.181   169.48.207.84   30210:30210/TCP,30211:30211/TCP   4m
@@ -64,7 +64,7 @@ The Hyperledger Composer REST server allows you to expose your deployed Business
     ```bash
     $ kubectl get svc
     NAME                   CLUSTER-IP       EXTERNAL-IP     PORT(S)                           AGE
-    blockchain-ca          172.21.19.128    169.48.207.86   30000:30000/TCP                   16m
+    blockchain-ca          172.21.19.128    169.48.207.86   30054:30054/TCP                   16m
     blockchain-orderer     172.21.194.183   169.47.102.85   31010:31010/TCP                   16m
     blockchain-org1peer1   172.21.165.205   169.48.207.83   30110:30110/TCP,30111:30111/TCP   16m
     blockchain-org2peer1   172.21.174.181   169.48.207.84   30210:30210/TCP,30211:30211/TCP   16m
@@ -118,7 +118,7 @@ The Hyperledger Fabric network created by these scripts defines two organisation
 				}
 			],
 			"ca": {
-				"url": "http://EXTERNAL_IP_CA:30000",
+				"url": "http://EXTERNAL_IP_CA:30054",
 				"name": "CA1"
 			},
 			"peers": [


### PR DESCRIPTION
We pinned the IBM Container Service scripts to Hyperledger Composer v0.13.2 when we introduced the breaking business network administrator changes. We did this so that we could avoid fixing the scripts which broke at the time, but now we need to fix them.

Changes are as follows:

- Change the Fabric CA port to 30054 so the scripts work with minikube

Relates to changes in another pull request:
https://github.com/IBM-Blockchain/ibm-container-service/pull/37